### PR TITLE
Feature/chat : AI 일기 파싱 로직 분리 및 ChatRepository 쿼리 에러 수정

### DIFF
--- a/src/main/java/org/delivery/voda/domain/chat/entity/Chat.java
+++ b/src/main/java/org/delivery/voda/domain/chat/entity/Chat.java
@@ -1,0 +1,48 @@
+package org.delivery.voda.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Chat {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JoinColumn(name = "user_id")
+  private Long id;
+
+  private Long memberId;
+
+  @Column(columnDefinition = "TEXT")
+  private String message;
+
+  @Enumerated(EnumType.STRING)
+  private SenderType sender;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  public enum SenderType {
+    USER, AI
+  }
+
+}

--- a/src/main/java/org/delivery/voda/domain/chat/entity/Chat.java
+++ b/src/main/java/org/delivery/voda/domain/chat/entity/Chat.java
@@ -5,16 +5,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.delivery.voda.domain.user.entity.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -27,10 +30,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Chat {
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "chat_id")
   private Long id;
 
-  private Long memberId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
 
   @Column(columnDefinition = "TEXT")
   private String message;

--- a/src/main/java/org/delivery/voda/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/org/delivery/voda/domain/chat/repository/ChatRepository.java
@@ -1,0 +1,13 @@
+package org.delivery.voda.domain.chat.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.delivery.voda.domain.chat.entity.Chat;
+import org.delivery.voda.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+  List<Chat> findAllByMemberIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+      User user, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/org/delivery/voda/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/org/delivery/voda/domain/chat/repository/ChatRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
-  List<Chat> findAllByMemberIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+  List<Chat> findAllByUserAndCreatedAtBetweenOrderByCreatedAtAsc(
       User user, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/delivery/voda/domain/chat/service/GeminiService.java
+++ b/src/main/java/org/delivery/voda/domain/chat/service/GeminiService.java
@@ -2,6 +2,7 @@ package org.delivery.voda.domain.chat.service;
 
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.delivery.voda.domain.chat.dto.request.ChatRequest;
@@ -40,6 +41,44 @@ public class GeminiService {
     }
   }
 
+
+  // 감정 분석 메서드
+  public String generateDiaryAndEmotion(List<String> chatHistory) {
+    try {
+      Client client = Client.builder().apiKey(apiKey).build();
+
+      //채팅 기록 전체 합치기
+      String conversationLog = String.join("\n", chatHistory);
+
+      String prompt = "너는 사용자의 하루 대화를 분석해서 일기를 대신 써주는 'AI 서기'야.\n" +
+          "아래 대화 기록을 바탕으로 다음 3가지 작업을 수행해줘.\n\n" +
+          "1. [일기 작성]: \n" +
+          "   - **반드시 '나'의 시점(1인칭)으로 작성해줘.** (예: '오늘 나는...', '친구랑 떡볶이를 먹었다.')\n" +
+          "   - 사용자가 직접 쓴 것처럼 자연스러운 구어체로 작성해.\n" +
+          "   - 분량은 3~5문장.\n\n" +
+          "2. [감정 선택]: 다음 6가지 중 오늘 기분을 가장 잘 나타내는 것 하나를 골라.\n" +
+          "   [보기: HAPPY, PEACE, SAD, ANXIETY, EXCITED, ANGRY]\n\n" +
+          "3. [제목 작성]: 일기 내용을 한눈에 볼 수 있는 짧고 임팩트 있는 제목을 지어줘. (10자 이내)\n\n" +
+          "응답 형식(반드시 지킬것):\n" +
+          "TITLE: {제목}\n" +
+          "MOOD: {감정키워드}\n" +
+          "DIARY: {일기내용}\n\n" +
+          "== 대화 기록 ==\n" +
+          conversationLog;
+
+      GenerateContentResponse response = client.models.generateContent(
+          "gemini-2.5-flash",
+          prompt,
+          null
+      );
+      return response.text();
+    }catch (Exception e) {
+      log.error("제미나이 일기 생성 중 에러 발생", e);
+      return "일기 생성에 실패했습니다.";
+    }
+  }
+
+
   // 캐릭터 설정 (프롬프트)
   private String getInstruction(int type) {
     switch (type) {
@@ -56,7 +95,7 @@ public class GeminiService {
         return "너는 논리적이고 까칠한 '현실주의자'야. 사용자의 고민에 대해 듣기 좋은 소리보다는 따끔한 현실적인 조언(팩트 폭력)을 해줘. " +
             "말투는 약간 냉소적이어야 해.";
       default:
-        return "너는 도움이 되는 AI 어시스턴트야.";
+        return "모든 대화는 길 필요 없어 짧게 한줄, 혹은 두 줄";
     }
   }
 }

--- a/src/main/java/org/delivery/voda/domain/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/org/delivery/voda/domain/diary/dto/response/DiaryResponse.java
@@ -21,7 +21,6 @@ public class DiaryResponse {
   private String imgUrl;
   private LocalDate writtenDate;
   private Mood mood;
-  // 예: "행복해요" (프론트에서 바로 쓰기 편하게 같이 줌)
   private String moodLabel;
   private DiaryType diaryType;
 

--- a/src/main/java/org/delivery/voda/domain/diary/enums/Mood.java
+++ b/src/main/java/org/delivery/voda/domain/diary/enums/Mood.java
@@ -10,7 +10,8 @@ public enum Mood {
   PEACE("PEACE", "평온해요"),
   SAD("SAD", "슬퍼요"),
   ANXIETY("ANXIETY", "불안해요"),
-  EXCITED("EXCITED", "신나요");
+  EXCITED("EXCITED", "신나요"),
+  ANGRY("ANGRY", "화나요");;
 
   private final String key;
   private final String mood;

--- a/src/main/java/org/delivery/voda/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/delivery/voda/domain/diary/repository/DiaryRepository.java
@@ -12,4 +12,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
   List<Diary> findAllByUserAndWrittenDateBetween(User user, LocalDate startDate, LocalDate endDate);
 
   Optional<Diary> findByUserAndWrittenDate(User user, LocalDate date);
+
+  boolean existsByUserAndWrittenDate(User user, LocalDate writtenDate);
 }

--- a/src/main/java/org/delivery/voda/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/delivery/voda/domain/diary/service/DiaryService.java
@@ -7,6 +7,8 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.delivery.voda.domain.chat.repository.ChatRepository;
+import org.delivery.voda.domain.chat.service.GeminiService;
 import org.delivery.voda.domain.diary.dto.request.DiaryRequest;
 import org.delivery.voda.domain.diary.dto.response.DiaryResponse;
 import org.delivery.voda.domain.diary.dto.response.DiarySummaryResponse;
@@ -27,6 +29,8 @@ public class DiaryService {
 
   private final DiaryRepository diaryRepository;
   private final UserRepository userRepository;
+  private final ChatRepository chatRepository;
+  private final GeminiService geminiService;
   private final ImageUploader imageUploader;
 
   public DiaryResponse createDiary(String email,DiaryRequest request, MultipartFile file) {
@@ -70,6 +74,7 @@ public class DiaryService {
         .map(DiarySummaryResponse::from)
         .collect(Collectors.toList());
   }
+
 
   // 일별 상세 조회 (해당 날짜 요청 시 전체 데이터)
   public DiaryResponse getDiaryDetail(String email, LocalDate date) {

--- a/src/main/java/org/delivery/voda/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/delivery/voda/domain/diary/service/DiaryService.java
@@ -2,11 +2,15 @@ package org.delivery.voda.domain.diary.service;
 
 import ch.qos.logback.core.spi.ErrorCodes;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.delivery.voda.domain.chat.entity.Chat;
 import org.delivery.voda.domain.chat.repository.ChatRepository;
 import org.delivery.voda.domain.chat.service.GeminiService;
 import org.delivery.voda.domain.diary.dto.request.DiaryRequest;
@@ -14,17 +18,21 @@ import org.delivery.voda.domain.diary.dto.response.DiaryResponse;
 import org.delivery.voda.domain.diary.dto.response.DiarySummaryResponse;
 import org.delivery.voda.domain.diary.entity.Diary;
 import org.delivery.voda.domain.diary.enums.DiaryType;
+import org.delivery.voda.domain.diary.enums.Mood;
 import org.delivery.voda.domain.diary.repository.DiaryRepository;
+import org.delivery.voda.domain.diary.util.AiDiaryParser;
 import org.delivery.voda.domain.image.ImageUploader;
 import org.delivery.voda.domain.user.entity.User;
 import org.delivery.voda.domain.user.repository.UserRepository;
 import org.delivery.voda.global.error.BusinessException;
 import org.delivery.voda.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DiaryService {
 
   private final DiaryRepository diaryRepository;
@@ -32,10 +40,14 @@ public class DiaryService {
   private final ChatRepository chatRepository;
   private final GeminiService geminiService;
   private final ImageUploader imageUploader;
+  private final AiDiaryParser aiDiaryParser;
 
+  //수동 일기 작성
   public DiaryResponse createDiary(String email,DiaryRequest request, MultipartFile file) {
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+    validateDiaryAlreadyExists(user, LocalDate.now());
 
     String imgUrl = null;
     if(file != null && !file.isEmpty()) {
@@ -57,6 +69,64 @@ public class DiaryService {
     return DiaryResponse.from(savedDiary);
 
   }
+
+
+  //AI 일기 작성
+  @Transactional
+  public void createAiDiary(User user) {
+    LocalDate today = LocalDate.now();
+    validateDiaryAlreadyExists(user, today);
+
+    //채팅 기록 가져오기
+    List<String> chatLogs = getChatLogsForToday(user, today);
+    // AI에게 요청
+    String aiResponse = geminiService.generateDiaryAndEmotion(chatLogs);
+    // 응답 해석
+    AiDiaryParser.AiResult result = aiDiaryParser.parse(aiResponse);
+    // 저장
+    saveAiDiary(user, result, today);
+  }
+
+  private List<String> getChatLogsForToday(User user, LocalDate today) {
+    LocalDateTime startOfDay = today.atStartOfDay();
+    LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+    List<Chat> chats = chatRepository.findAllByUserAndCreatedAtBetweenOrderByCreatedAtAsc(
+        user, startOfDay, endOfDay);
+
+    if(chats.isEmpty()) {
+      throw new BusinessException(ErrorCode.CHAT_NOT_FOUND);
+    }
+
+    return chats.stream()
+        .map(chat -> chat.getSender() + ": " + chat.getMessage())
+        .collect(Collectors.toList());
+  }
+
+  // AI 응답 파싱 내용 저장
+  private void saveAiDiary(User user, AiDiaryParser.AiResult result, LocalDate date) {
+    Diary diary = Diary.builder()
+        .user(user)
+        .title(result.getTitle())
+        .mood(result.getMood())
+        .description(result.getContent())
+        .writtenDate(date)
+        .diaryType(DiaryType.AI_GENERATED)
+        .imgUrl(null)
+        .build();
+
+    diaryRepository.save(diary);
+    log.info("AI 일기 저장 성공: User ID={}, Date={}", user.getId(), date);
+    }
+
+
+  //일기 중복 검증 메서드
+  private void validateDiaryAlreadyExists(User user, LocalDate date) {
+    if(diaryRepository.existsByUserAndWrittenDate(user, date)) {
+      throw  new BusinessException(ErrorCode.DIARY_ALREADY_EXISTS);
+    }
+  }
+
 
   //해당 달 간단 내용
   public List<DiarySummaryResponse> getMonthlyDiaries(String email, int year, int month) {
@@ -86,7 +156,5 @@ public class DiaryService {
 
     return DiaryResponse.from(diary);
   }
-
-
 
 }

--- a/src/main/java/org/delivery/voda/domain/diary/util/AiDiaryParser.java
+++ b/src/main/java/org/delivery/voda/domain/diary/util/AiDiaryParser.java
@@ -1,0 +1,53 @@
+package org.delivery.voda.domain.diary.util;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.delivery.voda.domain.diary.enums.Mood;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AiDiaryParser {
+  @Getter
+  @Builder
+  public static class AiResult {
+    private String title;
+    private Mood mood;
+    private String content;
+  }
+
+  public AiResult parse(String aiResponse) {
+    try {
+      String title = extractValue(aiResponse, "TITLE:");
+      String moodStr = extractValue(aiResponse, "MOOD:");
+      String content = extractValue(aiResponse, "DIARY:");
+
+      Mood mood = Mood.valueOf(moodStr.toUpperCase().trim());
+
+      return AiResult.builder()
+          .title(title)
+          .mood(mood)
+          .content(content)
+          .build();
+    }catch (Exception e) {
+      throw new RuntimeException("AI 응답 파싱 실패", e);
+    }
+  }
+
+  private String extractValue(String text, String key) {
+    int startIndex = text.indexOf(key);
+
+
+    if(startIndex == -1) return "";
+
+    String temp = text.substring(startIndex + key.length()).trim();
+
+    if (key.equals("DIARY:")) return temp;
+
+    int nextLineIndex = temp.indexOf("\n");
+    if(nextLineIndex != -1) {
+      return temp.substring(0, nextLineIndex).trim();
+    }
+    return temp;
+  }
+
+}

--- a/src/main/java/org/delivery/voda/global/error/ErrorCode.java
+++ b/src/main/java/org/delivery/voda/global/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
   DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일기를 찾을 수 없습니다."),
   DIARY_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 날짜에 이미 작성된 일기가 있습니다."),
+  CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 채팅을 찾을 수 없습니다."),
 
   IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
   INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다.");


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
 Feature/chat -> main

### 변경 사항
코드 복잡도를 줄이기 위해 응답 파싱 로직을 별도 클래스로 분리하고, 서버 실행 시 발생하던 JPA 쿼리 메서드 이름 불일치 에러를 해결

- #9 